### PR TITLE
Updated method reportTCresult with platformid

### DIFF
--- a/src/testlink/testlinkapi.py
+++ b/src/testlink/testlinkapi.py
@@ -386,7 +386,7 @@ class TestlinkAPIClient(object):
         self.stepsList = []                    
         return ret 
 
-    def reportTCResult(self, testcaseid, testplanid, buildname, status, notes ):
+    def reportTCResult(self, testcaseid, testplanid, buildname, platformid, status, notes ):
         """
         Report execution result
         testcaseid: internal testlink id of the test case
@@ -402,6 +402,7 @@ class TestlinkAPIClient(object):
                 'testplanid' : testplanid,
                 'status': status,
                 'buildname': buildname,
+                'platformid': platformid,
                 'notes': str(notes)
                 }
         return self._callServer('reportTCResult', argsAPI)


### PR DESCRIPTION
Hi Anton, 

we're running a Testlink 1.9.3 and I discovered that there were some changes in the testlink API in between 1.8 and 1.9 (can't pinpoint exactly which release).
The issue I ran into was that reportTCresult now requires platformid as well.
So I updated that and I think by looking at the branch graphics that your repo is the latest "master/main".
We might need to handle backwards compatibility, but I'm a bit unsure if there is a "officially supported" version of the Testlink API that this project supports, so I'm looking forward to any comments you might have.

Nice to meet you btw :-)
